### PR TITLE
Wait if a queued status is reported

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -119,16 +119,32 @@ def test_validate_ipv6_fail():
     assert not validate_ipv6('127.0.0.1')
 
 
-def test_wait_for_vcenter_task_success():
-    task = mock.MagicMock()
-    task.info.state = vim.TaskInfo.State.success
-    task.info.result = 'hello'
-    assert wait_for_vcenter_task(task, 'description', timeout=1) == 'hello'
+def test_wait_for_vcenter_task_wait_for_success():
+    task = mock.Mock(vim.Task)
+
+    class TaskInfoTimeline:
+        def __init__(self, states, result):
+            self.result = result
+            self._state_iter = iter(states)
+
+        @property
+        def state(self):
+            return next(self._state_iter)
+    task.info = TaskInfoTimeline(
+        result='hello', states=(
+            vim.TaskInfo.State.queued, vim.TaskInfo.State.running,
+            # Need success twice (ATM) since it is looked up again after poll
+            # loop
+            vim.TaskInfo.State.success, vim.TaskInfo.State.success))
+    assert wait_for_vcenter_task(
+        task, 'description', timeout=2, _poll_interval=0) == 'hello'
+    with pytest.raises(StopIteration):
+        task.info.state
 
 
 def test_wait_for_vcenter_task_fail():
     task = mock.MagicMock()
-    task.info.state = 'Error'
+    task.info.state = vim.TaskInfo.State.error
     task.info.error = Exception
     with pytest.raises(Exception):
         wait_for_vcenter_task(task, 'description', timeout=1)

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -136,7 +136,7 @@ def test_wait_for_vcenter_task_fail():
 
 def test_wait_for_vcenter_task_fail_no_exception():
     task = mock.MagicMock()
-    task.info.state = 'Error'
+    task.info.state = vim.TaskInfo.State.error
     task.info.error = None
     wait_for_vcenter_task(task, 'description', timeout=1)
 

--- a/vcdriver/helpers.py
+++ b/vcdriver/helpers.py
@@ -186,7 +186,7 @@ _TERMINAL_STATES = frozenset(
     (vim.TaskInfo.State.success, vim.TaskInfo.State.error))
 
 
-def wait_for_vcenter_task(task, task_description, timeout):
+def wait_for_vcenter_task(task, task_description, timeout, _poll_interval=1):
     """
     Wait for a vcenter task to finish
     :param task: A vcenter task object
@@ -198,7 +198,7 @@ def wait_for_vcenter_task(task, task_description, timeout):
     :raise: TimeoutError: If the timeout is reached
     """
     timeout_loop(
-        timeout, task_description, 1, False,
+        timeout, task_description, _poll_interval, False,
         callback=lambda: task.info.state in _TERMINAL_STATES,
     )
     if task.info.state == vim.TaskInfo.State.success:

--- a/vcdriver/helpers.py
+++ b/vcdriver/helpers.py
@@ -182,6 +182,10 @@ def validate_ipv6(ip):
     return True
 
 
+_TERMINAL_STATES = frozenset(
+    (vim.TaskInfo.State.success, vim.TaskInfo.State.error))
+
+
 def wait_for_vcenter_task(task, task_description, timeout):
     """
     Wait for a vcenter task to finish
@@ -195,7 +199,7 @@ def wait_for_vcenter_task(task, task_description, timeout):
     """
     timeout_loop(
         timeout, task_description, 1, False,
-        callback=lambda: task.info.state != vim.TaskInfo.State.running,
+        callback=lambda: task.info.state in _TERMINAL_STATES,
     )
     if task.info.state == vim.TaskInfo.State.success:
         return task.info.result


### PR DESCRIPTION
Right now we return in this case, which can cause races because we didn't wait.